### PR TITLE
Fix `--force` to update existing manifest rather than overwrite

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+0.3.9
+-----
+
+* Fixed `--force` so it loads the existing data instead of recreating the manifest file from scratch.
+
 0.3.8
 -----
 

--- a/yamanifest/yamf.py
+++ b/yamanifest/yamf.py
@@ -37,7 +37,6 @@ def parse_args(args):
     parser_add = subparsers.add_parser('add', help='Add filepaths to manifest')
     parser_add.add_argument('-n','--name', default='manifest.yaml', action='store', help='Manifest file name')
     parser_add.add_argument("-f","--force", help="Force overwrite of existing manifest", action='store_true')
-    parser_add.add_argument("-u", "--update", help="Update entries of existing manifest", action="store_true")
     parser_add.add_argument("-s","--hashes", help="Use only these hashing functions", action='append')
     parser_add.add_argument("files", help="File paths to add to manifest", nargs='+')
 

--- a/yamanifest/yamf.py
+++ b/yamanifest/yamf.py
@@ -37,6 +37,7 @@ def parse_args(args):
     parser_add = subparsers.add_parser('add', help='Add filepaths to manifest')
     parser_add.add_argument('-n','--name', default='manifest.yaml', action='store', help='Manifest file name')
     parser_add.add_argument("-f","--force", help="Force overwrite of existing manifest", action='store_true')
+    parser_add.add_argument("-u", "--update", help="Update entries of existing manifest", action="store_true")
     parser_add.add_argument("-s","--hashes", help="Use only these hashing functions", action='append')
     parser_add.add_argument("files", help="File paths to add to manifest", nargs='+')
 
@@ -56,9 +57,8 @@ def main(args):
     mf1 = mf.Manifest(args.name)
     if args.command == 'add':
         if os.path.exists(args.name):
-            # If manifest exists load existing hash data unless --force
-            if not args.force:
-                mf1.load()
+            # If manifest exists load existing hash data
+            mf1.load()
         mf1.add(args.files,hashfn=args.hashes,force=args.force)
         mf1.dump()
 


### PR DESCRIPTION
## Background 

Currently, `--force` overwrites the entire file from scratch. Instead, we should update existing entries. 

In this PR:
- **Update ChangeLog for `0.3.9`**
- **Load the existing manifest data even if `--force` is specified**

## Testing

- Used the inbuilt `py.test` - all pass. 
- Ran the following and verified the correctness:
  ```bash
  yamf -n manifest.yaml --force AUTHORS     # added a single entry for AUTHORS correctly
  yamf -n manifest.yaml --force README.rst  # added a single entry for README.rst correctly
  echo "WOW" >> README.rst                  # to update the potential hash
  yamf -n manifest.yaml --force README.rest # updated the entry for README.rest correctly, keeping the AUTHORS entry
  ```
Closes ACCESS-NRI/model-config-inputs#4
