### PR TITLE
Revert change to binhash calculations

### DIFF
--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -49,7 +49,7 @@ def _binhash(path, size, include_mtime):
     m = hashlib.new('md5')
     with io.open(path, mode="rb") as fd:
         # Size limited hashing, so prepend the filename, size and optionally modification time 
-        hashstring = str(os.path.getsize(path)) + os.path.basename(path)
+        hashstring = os.path.basename(path) + str(os.path.getsize(path))
         if include_mtime:
             hashstring +=str(os.path.getmtime(path))
         m.update(hashstring.encode())


### PR DESCRIPTION
Changed back the order of filename and file size in the `hashstring` used to generate `binhashes`. This means the calculated `binhash` remain the same with the calculated `binhash` with an earlier `yamanifest` version `0.3.8`.

Tested with the current pytests, and with virtual environment running the latest version of payu and a pre-existing payu configuration to check the manifest `binhash` values do not change.

Closes #20