### PR TITLE
Remove nchash dependency

### DIFF
--- a/.conda/env_dev.yml
+++ b/.conda/env_dev.yml
@@ -12,7 +12,6 @@ dependencies:
     - libnetcdf
     - six
     - PyYAML
-    - nchash>=0.1.5
     - pytest
     - pytest-cov
     - versioneer

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -27,8 +27,6 @@ requirements:
         - python
         - six
         - pyyaml
-        - nchash
-
 test:
     imports:
         - yamanifest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,6 +55,21 @@ jobs:
           auto-update-conda: false
           show-channel-urls: true
 
+      - name: Enforce .tar.bz2 packages
+          # Temporary work-arounds while the action uibcdf/action-build-and-upload-conda-packages gets updated:
+          # We create a `~/.condarc` file with the correct options to enforce the use of `.tar.bz2` packages
+          # and we set the channels to be used by conda build
+        shell: bash
+        run: |
+            cat > ~/.condarc << EOF
+            conda-build:
+                pkg_format: .tar.bz2
+            channels:
+                - accessnri
+                - conda-forge
+                - nodefaults
+            EOF
+
       - name: Verify conda recipe
         shell: bash -el {0}
         # Ignores: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "PyYAML",
-    "nchash>=0.1.5",
     "six"
 ]
 

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -18,10 +18,8 @@ from __future__ import print_function
 
 import glob
 import os
-import pdb  # Add pdb.set_trace() to set breakpoints
 import shutil
 import sys
-import time
 
 import pytest
 
@@ -32,7 +30,6 @@ from yamanifest import yamf
 
 verbose = True
 
-import os
 
 
 def touch(fname, times=None):
@@ -119,7 +116,7 @@ def test_manifest_netcdf():
         mf1 = mf.Manifest('mf1.yaml')
 
         for filepath in glob.glob('*.nc'):
-            mf1.add(filepath,['md5','sha1'])
+            mf1.add(filepath,['binhash','md5','sha1'])
 
         mf1.dump()
 
@@ -128,7 +125,7 @@ def test_manifest_netcdf():
         mf2 = mf.Manifest('mf2.yaml')
         
         for filepath in glob.glob('*.nc'):
-            mf2.add(filepath,['md5','sha1'])
+            mf2.add(filepath,['binhash','md5','sha1'])
 
         mf2.dump()
 
@@ -155,10 +152,10 @@ def test_manifest_netcdf_changed_time():
 
         for filepath in glob.glob('*.nc'):
             touch(filepath)
-            mf3.add(filepath,['md5','sha1'])
+            mf3.add(filepath,['md5','sha1','binhash'])
 
         mf3.dump()
-
+        mf3.add(filepath,['md5','sha1','binhash'])
         mf2 = mf.Manifest('mf2.yaml')
         mf2.load()
 
@@ -210,7 +207,7 @@ def test_manifest_find():
             assert(mf1.find(hashfn,hashval) == filepath)
 
         # Test for one we know shouldn't be there
-        for hashfn in ['binhash',]:
+        for hashfn in ['binhash-nomtime',]:
             hashval = mf1.get(filepath,hashfn)
             print(hashfn,hashval,filepath,mf1.find(hashfn,hashval))
             assert(mf1.find(hashfn,hashval) == None)

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -16,10 +16,14 @@ limitations under the License.
 
 from __future__ import print_function
 
-import pytest
-import sys, os, time, glob
+import glob
+import os
+import pdb  # Add pdb.set_trace() to set breakpoints
 import shutil
-import pdb # Add pdb.set_trace() to set breakpoints
+import sys
+import time
+
+import pytest
 
 print("Version: {}".format(sys.version))
 
@@ -29,6 +33,8 @@ from yamanifest import yamf
 verbose = True
 
 import os
+
+
 def touch(fname, times=None):
     with open(fname, 'a'):
         os.utime(fname, times)
@@ -113,7 +119,7 @@ def test_manifest_netcdf():
         mf1 = mf.Manifest('mf1.yaml')
 
         for filepath in glob.glob('*.nc'):
-            mf1.add(filepath,['nchash','md5','sha1'])
+            mf1.add(filepath,['md5','sha1'])
 
         mf1.dump()
 
@@ -122,7 +128,7 @@ def test_manifest_netcdf():
         mf2 = mf.Manifest('mf2.yaml')
         
         for filepath in glob.glob('*.nc'):
-            mf2.add(filepath,['nchash','md5','sha1'])
+            mf2.add(filepath,['md5','sha1'])
 
         mf2.dump()
 
@@ -136,7 +142,7 @@ def test_manifest_netcdf():
 
         mf1 = mf.Manifest('mf1.yaml')
         
-        mf1.add(glob.glob('*.nc'),['nchash'])
+        mf1.add(glob.glob('*.nc'),['binhash'])
         mf1.add(hashfn=['md5','sha1'])
 
     assert(mf1.equals(mf2))
@@ -149,7 +155,7 @@ def test_manifest_netcdf_changed_time():
 
         for filepath in glob.glob('*.nc'):
             touch(filepath)
-            mf3.add(filepath,['nchash','md5','sha1'])
+            mf3.add(filepath,['md5','sha1'])
 
         mf3.dump()
 
@@ -198,7 +204,7 @@ def test_manifest_find():
 
     for filepath in mf1:
         # Test for hashes we know should be in the manifest
-        for hashfn in ['nchash','md5','sha1']:
+        for hashfn in ['md5','sha1']:
             hashval = mf1.get(filepath,hashfn)
             print(hashfn,hashval,filepath,mf1.find(hashfn,hashval))
             assert(mf1.find(hashfn,hashval) == filepath)
@@ -213,9 +219,9 @@ def test_manifest_find():
 
         mf2 = mf.Manifest('mf2.yaml')
 
-        # Make a manifest only with nchash
+        # Make a manifest only with md5
         for filepath in glob.glob('*.nc'):
-            mf1.add(filepath,['nchash'])
+            mf1.add(filepath,['md5'])
 
         # Update with hashes from mf1
         mf2.update_matching_hashes(mf1)
@@ -227,7 +233,7 @@ def test_manifest_find():
     mf3 = mf.Manifest('mf3.yaml')
     
     for filepath in glob.glob(os.path.join('test','testfiles','*.nc')):
-        mf3.add(filepath,['nchash'])
+        mf3.add(filepath,['md5'])
 
     mf3.update_matching_hashes(mf1)
 
@@ -241,7 +247,7 @@ def test_manifest_with_mixed_file_types():
         mf6 = mf.Manifest('mf6.yaml')
 
         for filepath in glob.glob('*.bin') + glob.glob('*.nc'):
-            mf6.add(filepath,hashfn=['nchash','binhash'])
+            mf6.add(filepath,hashfn=['binhash'])
 
         mf6.dump()
         assert(mf6.check())
@@ -261,7 +267,7 @@ def test_open_manifest_and_add():
         mf7 = mf.Manifest('mf7.yaml')
 
         for filepath in glob.glob('*.nc'):
-            mf7.add(filepath,hashfn=['nchash','binhash'])
+            mf7.add(filepath,hashfn=['binhash'])
 
         mf7.dump()
 
@@ -271,7 +277,7 @@ def test_open_manifest_and_add():
         mf7.load()
 
         for filepath in glob.glob('*.bin'):
-            mf7.add(filepath,hashfn=['nchash','binhash'])
+            mf7.add(filepath,hashfn=['binhash'])
 
         mf7.dump()
 
@@ -293,7 +299,7 @@ def test_yamf():
     with cd(os.path.join('test','testfiles_copy')):
 
         files  = glob.glob('*.bin') + glob.glob('*.nc')
-        yamf.main_parse_args(["add","-n","mf8.yaml", "-s", "binhash", "-s", "nchash"] + files)
+        yamf.main_parse_args(["add","-n","mf8.yaml", "-s", "binhash"] + files)
 
         mf8 = mf.Manifest('mf8.yaml')
         mf8.load()
@@ -302,7 +308,7 @@ def test_yamf():
         mf6.load()
 
         assert(mf8.equals(mf6))
-        assert(yamf.main_parse_args(["check","-n","mf8.yaml", "-s", "binhash", "-s", "nchash"]))
+        assert(yamf.main_parse_args(["check","-n","mf8.yaml", "-s", "binhash"]))
 
 
 def test_shortcircuit_condition():
@@ -362,7 +368,7 @@ def test_shortcircuit_add():
         mf6 = mf.Manifest('mf6.yaml')
 
         for filepath in glob.glob('*.bin') + glob.glob('*.nc'):
-            mf6.add(filepath,hashfn=['nchash','binhash'],shortcircuit=True)
+            mf6.add(filepath,hashfn=['md5'],shortcircuit=True)
 
         mf6.dump()
         # print("mf6: ",mf6.data)
@@ -370,9 +376,9 @@ def test_shortcircuit_add():
 
         assert(mf6.check())
 
-        # Should have no nchash for the bin files
+        # Should have no sha1 for the bin files
         for filepath in glob.glob('*.bin'):
-            assert(mf6.get(filepath,hashfn='nchash') == None)
+            assert(mf6.get(filepath,hashfn='sha1') == None)
 
         # Should have no binhash for the netcdf files
         for filepath in glob.glob('*.nc'):
@@ -385,7 +391,7 @@ def test_malformed_file():
         mf9 = mf.Manifest('mf9.yaml')
 
         for filepath in glob.glob('*.nc'):
-            mf9.add(filepath,['nchash','md5','sha1'])
+            mf9.add(filepath,['md5','sha1'])
 
         # Intentionally alter the format string
         mf9.header["format"] = 'bogus'

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -18,13 +18,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import hashlib
 import io
 import os
 import sys
-from nchash import NCDataHash, NotNetcdfFileError
 
 length=io.DEFAULT_BUFFER_SIZE
 one_hundred_megabytes = 104857600
@@ -32,18 +31,8 @@ one_hundred_megabytes = 104857600
 # List of supported hashes and the ordering used to determine relative expense of
 # calculation
 supported_hashes = [
-    'nchash', 'binhash', 'binhash-nomtime', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'
+    'binhash', 'binhash-nomtime', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'
 ]
-
-def _nchash(path):
-    hashval = ''
-    m = NCDataHash(path)
-    try:
-        hashval = m.gethash()
-    except NotNetcdfFileError as e:
-        sys.stderr.write(str(e))
-        hashval = None
-    return hashval
 
 def _binhash(path, size, include_mtime):
     m = hashlib.new('md5')
@@ -81,9 +70,7 @@ def hash(path, hashfn, size=one_hundred_megabytes):
     if hashfn not in supported_hashes:
         sys.stderr.write('\nUnsupported hash function {}, skipping {}\n'.format(hashfn, path))
     try:
-        if hashfn == 'nchash':
-            return _nchash(path)
-        elif hashfn == 'binhash':
+        if hashfn == 'binhash':
             return _binhash(path, one_hundred_megabytes, True)
         elif hashfn == 'binhash-nomtime':
             return _binhash(path, one_hundred_megabytes, False)


### PR DESCRIPTION
The yamanifest conda package requires nchash
Based on discussions with @charles-turner-1 and @aidanheerdegen the package is not used any more and the dependency to nchash should be removed.