### PR TITLE
Add faster (~6-10x) hashing algorithm

### DIFF
--- a/.conda/env_dev.yml
+++ b/.conda/env_dev.yml
@@ -15,3 +15,4 @@ dependencies:
     - pytest
     - pytest-cov
     - versioneer
+    - python-xxhash

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -27,6 +27,7 @@ requirements:
         - python
         - six
         - pyyaml
+        - xxhash
 test:
     imports:
         - yamanifest

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -82,7 +82,7 @@ def test_manifest_read_write():
     files = ['file1','file2']
 
     for filepath in files:
-        mf1.add(os.path.join('test',filepath),['md5','sha1'])
+        mf1.add(os.path.join('test',filepath),['binhash-xxh','md5','sha1'])
 
     assert(len(mf1) == len(files))
 
@@ -116,7 +116,7 @@ def test_manifest_netcdf():
         mf1 = mf.Manifest('mf1.yaml')
 
         for filepath in glob.glob('*.nc'):
-            mf1.add(filepath,['binhash','md5','sha1'])
+            mf1.add(filepath,['binhash-xxh','binhash','md5','sha1'])
 
         mf1.dump()
 
@@ -125,7 +125,7 @@ def test_manifest_netcdf():
         mf2 = mf.Manifest('mf2.yaml')
         
         for filepath in glob.glob('*.nc'):
-            mf2.add(filepath,['binhash','md5','sha1'])
+            mf2.add(filepath,['binhash-xxh','binhash','md5','sha1'])
 
         mf2.dump()
 
@@ -139,7 +139,7 @@ def test_manifest_netcdf():
 
         mf1 = mf.Manifest('mf1.yaml')
         
-        mf1.add(glob.glob('*.nc'),['binhash'])
+        mf1.add(glob.glob('*.nc'),['binhash-xxh','binhash'])
         mf1.add(hashfn=['md5','sha1'])
 
     assert(mf1.equals(mf2))
@@ -152,10 +152,10 @@ def test_manifest_netcdf_changed_time():
 
         for filepath in glob.glob('*.nc'):
             touch(filepath)
-            mf3.add(filepath,['md5','sha1','binhash'])
+            mf3.add(filepath,['md5','sha1','binhash','binhash-xxh'])
 
         mf3.dump()
-        mf3.add(filepath,['md5','sha1','binhash'])
+        mf3.add(filepath,['md5','sha1','binhash','binhash-xxh'])
         mf2 = mf.Manifest('mf2.yaml')
         mf2.load()
 
@@ -176,7 +176,7 @@ def test_manifest_hash_with_binhash():
         mf4 = mf.Manifest('mf4.yaml')
 
         for filepath in glob.glob('*.bin'):
-            mf4.add(filepath,hashfn=['binhash', 'binhash-nomtime'])
+            mf4.add(filepath,hashfn=['binhash', 'binhash-nomtime', 'binhash-xxh'])
 
         mf4.dump()
         assert(mf4.check())
@@ -185,7 +185,7 @@ def test_manifest_hash_with_binhash():
 
         for filepath in glob.glob('*.bin'):
             touch(filepath)
-            mf5.add(filepath,hashfn=['binhash', 'binhash-nomtime'])
+            mf5.add(filepath,hashfn=['binhash', 'binhash-nomtime', 'binhash-xxh'])
 
         hashvals = {}
         assert(not mf4.check())

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -75,7 +75,7 @@ def hash(path, hashfn, size=one_hundred_megabytes):
     try:
         if hashfn == 'binhash-xxh':
             return _binhash(path, one_hundred_megabytes, True, use_xxh=True)
-        if hashfn == 'binhash':
+        elif hashfn == 'binhash':
             return _binhash(path, one_hundred_megabytes, True)
         elif hashfn == 'binhash-nomtime':
             return _binhash(path, one_hundred_megabytes, False)


### PR DESCRIPTION
- Adds the xxhash algorithm - comes in about 6-10x faster than an MD5 hash, over the range of test cases I've run.
- I've stuck it at the top of the `if-else` chain in `hashing.hash` since it's so much faster than the other hashes I'd rather sit the overhead elsewhere.
- Add relevant tests.

xxhash: https://github.com/Cyan4973/xxHash
xxhash Python Bindings: https://github.com/ifduyue/python-xxhash


<img width="823" alt="Screenshot 2025-06-20 at 8 26 04 am" src="https://github.com/user-attachments/assets/a01f3e34-047b-4e9c-8241-21087cdde0ca" />

## More context

The `build-esm-datastore` catalog utility uses yamanifest to track whether files in the catalogs have changed, but is basically way too slow to be user friendly - think on the order of a minute to a couple of minutes to run. I can't remember where, but I've seen a couple of notebooks where people are using that utility, but have commented it out to avoid rerunning it.

I've been playing with performance improvements with the hashing on and off for a good while now, and didn't manage to make any headway with either Cython or Maturin - basically everything works out to be about the same speed. Presumably the MD5 hash that binhash uses is a compiled C extension (I haven't checked but it seems likely), which eats up nearly all the runtime & so any attempts to speed hashing by using compiled extensions do next to nothing to improve performance.

Anyhow, xxhash is just a much faster hashing algorithm than MD5. It looks relatively well maintained and has no dependencies, which is pretty crucial IMO.