### PR TITLE
Allow configurable hash length - no tests yet

### DIFF
--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -67,13 +67,16 @@ def hash(path, hashfn, size=one_hundred_megabytes):
 
     TODO: make plugins that allow this transparently
     """
+    size = size or one_hundred_megabytes
     if hashfn not in supported_hashes:
         sys.stderr.write('\nUnsupported hash function {}, skipping {}\n'.format(hashfn, path))
     try:
-        if hashfn == 'binhash':
-            return _binhash(path, one_hundred_megabytes, True)
+        if hashfn == 'binhash-xxh':
+            return _binhash(path, size, True, use_xxh=True)
+        elif hashfn == 'binhash':
+            return _binhash(path, size, True)
         elif hashfn == 'binhash-nomtime':
-            return _binhash(path, one_hundred_megabytes, False)
+            return _binhash(path, size, False)
         else:
             return _hashlib(path, hashfn)
     except IOError as e:

--- a/yamanifest/manifest.py
+++ b/yamanifest/manifest.py
@@ -47,18 +47,32 @@ class Manifest(object):
 
     Attributes:
         path: a Path object for the manifest file
+        hashes: a set of hash functions to use when checking manifest validity
+        hashmax: maximum size of file to hash in bytes, default is 100MB
         data: an dictionary of manifest items
     """
 
-    def __init__(self, path, hashes=None, **kwargs):
+    def __init__(self, path, hashes=None, hashmax=None, **kwargs):
         """
         Return a Manifest object, initialised with a path
         to the manifest file. Optionally specify default
         order of hashes to use when checking manifest validity
+
+        Parameters:
+        -----------
+        path : str
+            Path to the manifest file
+        hashes : list, optional
+            List of hashes to use when checking manifest validity.
+            Default is ['binhash', 'md5'].
+        hashmax : int, optional
+            Maximum size of file to hash in bytes. Default is 100MB.
+
         """
         self.path = path
         self.data = {}
         self.header = {}
+        self.hashmax = hashmax
         try:
             self.numproc = mp.cpu_count()
         except NotImplementedError:
@@ -269,7 +283,7 @@ class Manifest(object):
 
         # print("Queuing jobs")
         for filepath, fn in zip(filepaths,hashfns):
-            results[filepath][fn] = pool.apply_async(hash, args=(self.data[filepath]["fullpath"], fn))
+            results[filepath][fn] = pool.apply_async(hash, args=(self.data[filepath]["fullpath"], fn, self.hashmax))
 
         pool.close()
         pool.join()


### PR DESCRIPTION
Allows for changing the amount of the file that is hashed.

See https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/355#issuecomment-2989613692:

> Something I didn't suggest before was to reduce the size of the chunk of the file that `binhash` slurps in. It defaults to 100Mb, so reducing to 10Mb is 10x less to hash.
> 
> 100Mb was chosen completely arbitrarily. The sensitivity to changes in the file are very dependent on the organisation of the data within the file, which is format dependent.

